### PR TITLE
增加betabooru的支持

### DIFF
--- a/Danbooru-Tags-Exporter.user.js
+++ b/Danbooru-Tags-Exporter.user.js
@@ -17,6 +17,7 @@
 // @match        https://danbooru.donmai.us/posts/*
 // @match        https://safebooru.donmai.us/posts/*
 // @match        https://aibooru.online/posts/*
+// @match        https://betabooru.donmai.us/posts/*
 // @icon         https://www.google.com/s2/favicons?sz=64&domain=donmai.us
 // @grant        GM_setClipboard
 // @grant        GM_notification


### PR DESCRIPTION
偶然发现的danbooru的第三个分站：[Betabooru](https://betabooru.donmai.us)，前端依然一致，所以加上去了。

别忘了更新你的sleazyfork 仓库！